### PR TITLE
Allow to specify the description of all uploaded files.

### DIFF
--- a/res/ext.SimpleBatchUpload.js
+++ b/res/ext.SimpleBatchUpload.js
@@ -67,7 +67,7 @@
 					var src_filename = data.files[ 0 ].name;
 					var filenode_text = src_filename;
 					var dst_filename = src_filename
-					var textdata = $( that ).fileupload( 'option', 'text' );
+					var textdata = $("#wfUploadDescription").val();
                     // It matches: 
                     //   other| +rename = !(\w+)[ -_/]*! =$1-}} 
                     // where: 

--- a/src/ParameterProvider.php
+++ b/src/ParameterProvider.php
@@ -48,13 +48,13 @@ class ParameterProvider {
 		$this->templateName = $templateName ? $templateName : '';
 	}
 
-	public function getEscapedUploadPageText(): string {
+	public function getUploadPageText(): string {
 
 		if ( $this->templateName === '' ) {
 			return '';
 		}
 
-		return '{{' . $this->getEscapedParameter( self::IDX_TEMPLATENAME ) . $this->getEscapedParameter( self::IDX_TEMPLATEPARAMETERS ) . '}}';
+		return '{{' . $this->getParameter( self::IDX_TEMPLATENAME ) . $this->getParameter( self::IDX_TEMPLATEPARAMETERS ) . '}}';
 	}
 
 	private function getEscapedParameter( int $key ): string {

--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -25,7 +25,7 @@
 namespace SimpleBatchUpload;
 use Parser;
 use PPFrame;
-
+use Html;
 
 /**
  * Class UploadButtonRenderer
@@ -85,13 +85,14 @@ class UploadButtonRenderer {
 	protected function getHtml( ParameterProvider $paramProvider ) {
 
 		$escapedUploadComment = $paramProvider->getEscapedUploadComment();
-		$escapedUploadPageText = $paramProvider->getEscapedUploadPageText();
+		$uploadPageText = $paramProvider->getUploadPageText();
 
 		return
 
 			'<label for="wfUploadDescription">' . \Message::newFromKey( 'upload-form-label-infoform-description' )->escaped() . ':</label><br>'.
-			'<span class="mw-input"><textarea name="wfUploadDescription" id="wfUploadDescription" cols="80" rows="8">' .
-			$escapedUploadPageText . '</textarea><br> ' .
+			'<span class="mw-input">' .
+			Html::element('textarea', ['name' => 'wfUploadDescription', 'id' => 'wfUploadDescription', 'cols' => '80', 'rows' => '8'], $uploadPageText) .
+			'</span><br> ' .
 			'<span class="fileupload-container"> ' .
 			'<span class="fileupload-dropzone fileinput-button"> ' .
 			'<i class="glyphicon glyphicon-plus"></i> ' .

--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -89,6 +89,9 @@ class UploadButtonRenderer {
 
 		return
 
+			'<label for="wfUploadDescription">' . \Message::newFromKey( 'upload-form-label-infoform-description' )->escaped() . ':</label><br>'.
+			'<span class="mw-input"><textarea name="wfUploadDescription" id="wfUploadDescription" cols="80" rows="8">' .
+			$escapedUploadPageText . '</textarea><br> ' .
 			'<span class="fileupload-container"> ' .
 			'<span class="fileupload-dropzone fileinput-button"> ' .
 			'<i class="glyphicon glyphicon-plus"></i> ' .
@@ -97,7 +100,6 @@ class UploadButtonRenderer {
 			'<input class="fileupload" type="file" name="file" multiple ' .
 			'    data-url="' . wfScript( 'api' ) . '" ' .
 			'    data-comment="' . $escapedUploadComment . '" ' .
-			'    data-text="' . $escapedUploadPageText . '" ' .
 			'> ' .
 			'</span><ul class="fileupload-results"></ul> ' .
 			'</span>';


### PR DESCRIPTION
Before, one could only use an existing template for this via the URL.
This now adds a textarea where you can compose a description just
like for the single file upload, which will be applied to all uploaded
files.

It's backwards compatible since a template passed via the URL will be
placed in the textarea as default content.