### PR TITLE
Remove id attribute from element that may be repeated on one page.

### DIFF
--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -89,20 +89,21 @@ class UploadButtonRenderer {
 
 		return
 
-			'<label for="wfUploadDescription">' . \Message::newFromKey( 'upload-form-label-infoform-description' )->escaped() . ':</label><br>'.
-			'<span class="mw-input">' .
-			Html::element('textarea', ['name' => 'wfUploadDescription', 'id' => 'wfUploadDescription', 'cols' => '80', 'rows' => '8'], $uploadPageText) .
-			'</span><br> ' .
+			'<label>' . \Message::newFromKey( 'upload-form-label-infoform-description' )->escaped() . ':<br>'.
+				'<span class="mw-input">' .
+					Html::element('textarea', ['name' => 'wfUploadDescription', 'cols' => '80', 'rows' => '8'], $uploadPageText) .
+				'</span>' .
+			'</label><br> '.
 			'<span class="fileupload-container"> ' .
-			'<span class="fileupload-dropzone fileinput-button"> ' .
-			'<i class="glyphicon glyphicon-plus"></i> ' .
-			'<span>' . \Message::newFromKey( 'simplebatchupload-buttonlabel' )->escaped() . '</span> ' .
-			'<!-- The file input field used as target for the file upload widget -->' .
-			'<input class="fileupload" type="file" name="file" multiple ' .
-			'    data-url="' . wfScript( 'api' ) . '" ' .
-			'    data-comment="' . $escapedUploadComment . '" ' .
-			'> ' .
-			'</span><ul class="fileupload-results"></ul> ' .
+				'<span class="fileupload-dropzone fileinput-button"> ' .
+					'<i class="glyphicon glyphicon-plus"></i> ' .
+					'<span>' . \Message::newFromKey( 'simplebatchupload-buttonlabel' )->escaped() . '</span> ' .
+					'<!-- The file input field used as target for the file upload widget -->' .
+					'<input class="fileupload" type="file" name="file" multiple ' .
+					'    data-url="' . wfScript( 'api' ) . '" ' .
+					'    data-comment="' . $escapedUploadComment . '" ' .
+					'> ' .
+				'</span><ul class="fileupload-results"></ul> ' .
 			'</span>';
 	}
 


### PR DESCRIPTION
Due to the fact this function may be called more than once on a page, it might introduce multiple identical textareas on the page. This will cause the <label for=""> to break (clicking on the <label> will simply cause the focus to be on the very first <textarea id="wfUploadDescription"> this way).
Using the label element as a wrapper element, which contains the textarea, will preserve this behaviour for a single upload box, while expanding this behaviour to work properly when multiple upload boxes occur on a single page (see for example https://oldschool.runescape.wiki/w/RuneScape:Batch_Upload).
This will also prevent invalid HTML from being generated by this extension (since re-using the same ID is invalid HTML).

Also indented code to more easily see the HTML structure at a glance.