### PR TITLE
Fix JS query selector to match the previous id-attribute change

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### SimpleBatchUpload 1.8.0
+
+Not released yet
+
+* Fix issues with multiple instances of `#batchupload` always inserting the content of the first instance.
+
 ### SimpleBatchUpload 1.7.0
 
 Released on April 13, 2021.

--- a/res/ext.SimpleBatchUpload.js
+++ b/res/ext.SimpleBatchUpload.js
@@ -67,7 +67,7 @@
 					var src_filename = data.files[ 0 ].name;
 					var filenode_text = src_filename;
 					var dst_filename = src_filename
-					var textdata = $("#wfUploadDescription").val();
+					var textdata = $(container).find('[name="wfUploadDescription"]').val();
                     // It matches: 
                     //   other| +rename = !(\w+)[ -_/]*! =$1-}} 
                     // where: 


### PR DESCRIPTION
The previous change, while necessary to make the HTML valid, did break batchuploading with a single instance, due to the id-attribute being used as a selector to find the textarea. This change will simply look for the name attribute within the same upload box, in order to match the correct textarea.

Also updated the release notes with a short description of both this change and the previous one.

It turns out that the current live version (1.7.0) actually has a major bug relating to having multiple instance of `#batchupload` on the page. Aside from just being invalid HTML with the id not being unique, this also causes the second batch upload to use the first batch upload's value. So a page with the following:

```
{{#batchupload:Foo}}
{{#batchupload:Bar}}
```

would cause files dropped on the "Bar" batchupload box to insert `{{Foo}}` onto the page. This is due to `$("#myID")` matching the first element with `id="myID"` to be matched, no matter what. The second element with that same `id="myID"` will simply be ignored by that query. This means that this change is not actually just a "let's comply with HTML standards" commit, but more of a "let's fix an actual breaking bug" commit.

The way I found out about the real effects the v1.7.0 bug have, was sadly the fact that on a wiki I edit on, this has actually caused hundreds of files to get the incorrect license added to them. I would recommend testing the unified changes of #43 and this PR, and if this does indeed work the way you expect it (which it should, going by my own testing), please release this fix ASAP, if at all possible.