### PR TITLE
Fix issue breaking batchuploads

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleBatchUpload",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://professional.wiki/ Professional.Wiki]",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### SimpleBatchUpload 1.8.1
+
+Not released yet
+
+* Fix an issue in the previous patch causing batch uploading to break.
+
 ### SimpleBatchUpload 1.8.0
 
 Released on April 30, 2021.

--- a/res/ext.SimpleBatchUpload.js
+++ b/res/ext.SimpleBatchUpload.js
@@ -40,7 +40,7 @@
 			} );
 		}
 
-		$( 'span.fileupload-container' ).each( function () {
+		$( 'div.fileupload-container' ).each( function () {
 
 			var container = this;
 
@@ -68,13 +68,13 @@
 					var filenode_text = src_filename;
 					var dst_filename = src_filename
 					var textdata = $(container).find('[name="wfUploadDescription"]').val();
-                    // It matches: 
-                    //   other| +rename = !(\w+)[ -_/]*! =$1-}} 
-                    // where: 
-                    //   what: (\w+)[ -_/]*
-                    //   with: $1-
-                    // Spaces are important in subst-pattern (after 2nd '=').
-                    var rename_regex = /\|\s*\+rename\s*=\s*([#\/@!])(.+)\1([gimuy]{0,5})\s*-->(.*?)(?=\||}}\s*$)/;
+					// It matches:
+					//   other| +rename = !(\w+)[ -_/]*! =$1-}}
+					// where:
+					//   what: (\w+)[ -_/]*
+					//   with: $1-
+					// Spaces are important in subst-pattern (after 2nd '=').
+					var rename_regex = /\|\s*\+rename\s*=\s*([#\/@!])(.+)\1([gimuy]{0,5})\s*-->(.*?)(?=\||}}\s*$)/;
 					var match = rename_regex.exec(textdata);
 					if ( match ) {
 						var pattern = RegExp(match[2], match[3]);

--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -89,12 +89,12 @@ class UploadButtonRenderer {
 
 		return
 
-			'<label>' . \Message::newFromKey( 'upload-form-label-infoform-description' )->escaped() . ':<br>'.
-				'<span class="mw-input">' .
-					Html::element('textarea', ['name' => 'wfUploadDescription', 'cols' => '80', 'rows' => '8'], $uploadPageText) .
-				'</span>' .
-			'</label><br> '.
-			'<span class="fileupload-container"> ' .
+			'<div class="fileupload-container"> ' .
+				'<label>' . \Message::newFromKey( 'upload-form-label-infoform-description' )->escaped() . ':<br>'.
+					'<span class="mw-input">' .
+						Html::element('textarea', ['name' => 'wfUploadDescription', 'cols' => '80', 'rows' => '8'], $uploadPageText) .
+					'</span>' .
+				'</label><br> '.
 				'<span class="fileupload-dropzone fileinput-button"> ' .
 					'<i class="glyphicon glyphicon-plus"></i> ' .
 					'<span>' . \Message::newFromKey( 'simplebatchupload-buttonlabel' )->escaped() . '</span> ' .
@@ -104,7 +104,7 @@ class UploadButtonRenderer {
 					'    data-comment="' . $escapedUploadComment . '" ' .
 					'> ' .
 				'</span><ul class="fileupload-results"></ul> ' .
-			'</span>';
+			'</div>';
 	}
 
 	/**


### PR DESCRIPTION
Due to one small oversight in my pushed changes last time, the textarea was not a child of the $(container). This was due to me failing to copy over all of my tested changes to my editor.

This means that with this small change, everything should be functioning perfectly. I've tested this more rigorously now and I'm over 99% sure this works as it should.

My apologies for my PR for 1.8.0 not working properly. I hope this new PR can make up for the mistake I made there.