### PR TITLE
Fix jquery.ui dependency for MW 1.35.0

### DIFF
--- a/src/SimpleBatchUpload.php
+++ b/src/SimpleBatchUpload.php
@@ -97,7 +97,7 @@ class SimpleBatchUpload {
 	}
 
 	protected function getUploadSupportModuleDefinition(): array {
-		if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.35.0', '>' ) ) {
+		if ( version_compare( $GLOBALS[ 'wgVersion' ], '1.35.0', '>=' ) ) {
 			$dependencies = [ 'jquery.ui' ];
 		} else {
 			$dependencies = [ 'jquery.ui.widget' ];


### PR DESCRIPTION
Per the commit message at https://github.com/ProfessionalWiki/SimpleBatchUpload/commit/0090322c5e7ea810df2ebbbf333cc6f188ff0d22, MW >= 1.35.0 should rely on jquery.ui instead of jquery.ui.widget. The current code only uses jquery.ui for MW > 1.35.0 instead of for MW >= 1.35.0, so installations of 1.35.0 do not properly import jquery.ui. This commit resolves that issue.