### PR TITLE
Support system messages for upload text

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -10,5 +10,7 @@
 	"batchupload": "Upload multiple files",
 	"simplebatchupload-buttonlabel": "Select files (or drop them here)...",
 	"simplebatchupload-comment": "Uploaded with [[mw:Special:MyLanguage/Extension:SimpleBatchUpload|SimpleBatchUpload]]",
-	"simplebatchupload-max-files-alert": "You cannot upload more than $1 {{PLURAL:$1|file|files}} at a time."
+	"simplebatchupload-filesummary": "<!-- Default file summary for uploaded new files via SimpleBatchUpload. -->",
+	"simplebatchupload-max-files-alert": "You cannot upload more than $1 {{PLURAL:$1|file|files}} at a time.",
+	"simplebatchupload-parameters": "<!-- Customization settings for SimpleBatchUpload subpages, see mw:Special:MyLanguage/Extension:SimpleBatchUpload#Customization for details. -->"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -10,7 +10,7 @@
 	"batchupload": "Upload multiple files",
 	"simplebatchupload-buttonlabel": "Select files (or drop them here)...",
 	"simplebatchupload-comment": "Uploaded with [[mw:Special:MyLanguage/Extension:SimpleBatchUpload|SimpleBatchUpload]]",
-	"simplebatchupload-filesummary": "<!-- Default file summary for uploaded new files via SimpleBatchUpload. -->",
+	"simplebatchupload-filesummary": "<!-- Default file summary for uploaded new files via SimpleBatchUpload -->",
 	"simplebatchupload-max-files-alert": "You cannot upload more than $1 {{PLURAL:$1|file|files}} at a time.",
-	"simplebatchupload-parameters": "<!-- Customization settings for SimpleBatchUpload subpages, see mw:Special:MyLanguage/Extension:SimpleBatchUpload#Customization for details. -->"
+	"simplebatchupload-parameters": "<!-- Customization settings for SimpleBatchUpload subpages, see mw:Special:MyLanguage/Extension:SimpleBatchUpload#Customization for details -->"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -10,5 +10,7 @@
 	"batchupload": "{{doc-special|BatchUpload}}",
 	"simplebatchupload-buttonlabel": "The label for the upload button",
 	"simplebatchupload-comment": "Comment saved with the upload. Do not translate '[[mw:Special:MyLanguage/Extension:SimpleBatchUpload|SimpleBatchUpload]]'",
-	"simplebatchupload-max-files-alert": "Alert saying there are too many files in a batch"
+	"simplebatchupload-filesummary": "Default file summary. Do not add anything outside the first comment. Do not translate 'SimpleBatchUpload'",
+	"simplebatchupload-max-files-alert": "Alert saying there are too many files in a batch",
+	"simplebatchupload-parameters": "Customization settings. Do not add anything outside the first comment. Do not translate 'SimpleBatchUpload' and 'mw:Special:MyLanguage/Extension:SimpleBatchUpload#Customization'"
 }

--- a/src/ParameterProvider.php
+++ b/src/ParameterProvider.php
@@ -95,7 +95,7 @@ class ParameterProvider {
 
 		if ( $paramMsg->exists() ) {
 
-			$paramLines = preg_replace( '/^\s*\*\s*/', '', explode( "\n", preg_replace( '/^[\s\n]*<!--[\s\S]*?-->[\s\n]*/', '', $paramMsg->plain() ) ) );
+			$paramLines = preg_replace( '/^\*\s*/', '', explode( "\n", preg_replace( '/^[\s\n]*<!--[\s\S]*?-->[\s\n]*/', '', $paramMsg->plain() ) ) );
 			$paramSet = array_map( [ $this, 'parseParamLine' ], $paramLines );
 			$paramMap = array_combine( array_column( $paramSet, 0 ), $paramSet );
 

--- a/src/ParameterProvider.php
+++ b/src/ParameterProvider.php
@@ -61,7 +61,7 @@ class ParameterProvider {
 		$fileSummaryMsg = Message::newFromKey( $msgKey, $templateParams );
 
 		if ( $fileSummaryMsg->exists() ) {
-			return preg_replace( '/^<!--.*?-->\n*/s', '', $fileSummaryMsg->plain() );
+			return preg_replace( '/^[\s\n]*<!--[\s\S]*?-->[\s\n]*/', '', $fileSummaryMsg->plain() );
 		}
 		else {
 			return '{{' . $templateName . $templateParams . '}}';
@@ -95,7 +95,7 @@ class ParameterProvider {
 
 		if ( $paramMsg->exists() ) {
 
-			$paramLines = explode( "\n", str_replace( '*', '', $paramMsg->plain() ) );
+			$paramLines = preg_replace( '/^\s*\*\s*/', '', explode( "\n", preg_replace( '/^[\s\n]*<!--[\s\S]*?-->[\s\n]*/', '', $paramMsg->plain() ) ) );
 			$paramSet = array_map( [ $this, 'parseParamLine' ], $paramLines );
 			$paramMap = array_combine( array_column( $paramSet, 0 ), $paramSet );
 

--- a/src/ParameterProvider.php
+++ b/src/ParameterProvider.php
@@ -50,11 +50,23 @@ class ParameterProvider {
 
 	public function getUploadPageText(): string {
 
-		if ( $this->templateName === '' ) {
-			return '';
+		$msgKey = 'simplebatchupload-filesummary';
+		$templateName = $this->getParameter( self::IDX_TEMPLATENAME );
+		$templateParams = preg_replace( '/^\|+/', '|', $this->getParameter( self::IDX_TEMPLATEPARAMETERS ) );
+
+		if ( $this->templateName !== '' ) {
+			$msgKey = $msgKey . '-' . $templateName;
 		}
 
-		return '{{' . $this->getParameter( self::IDX_TEMPLATENAME ) . $this->getParameter( self::IDX_TEMPLATEPARAMETERS ) . '}}';
+		$fileSummaryMsg = Message::newFromKey( $msgKey, $templateParams );
+
+		if ( $fileSummaryMsg->exists() ) {
+			return preg_replace( '/^<!--.*?-->\n*/s', '', $fileSummaryMsg->plain() );
+		}
+		else {
+			return '{{' . $templateName . $templateParams . '}}';
+		}
+
 	}
 
 	private function getEscapedParameter( int $key ): string {
@@ -83,7 +95,7 @@ class ParameterProvider {
 
 		if ( $paramMsg->exists() ) {
 
-			$paramLines = explode( "\n", $paramMsg->plain() );
+			$paramLines = explode( "\n", str_replace( '*', '', $paramMsg->plain() ) );
 			$paramSet = array_map( [ $this, 'parseParamLine' ], $paramLines );
 			$paramMap = array_combine( array_column( $paramSet, 0 ), $paramSet );
 

--- a/src/SimpleBatchUpload.alias.php
+++ b/src/SimpleBatchUpload.alias.php
@@ -29,3 +29,21 @@ $specialPageAliases = [];
 $specialPageAliases['en'] = [
 	'BatchUpload' => [ 'BatchUpload' ],
 ];
+
+/** Simplified Chinese
+ */
+$specialPageAliases['zh-hans'] = [
+	'BatchUpload' => [ '批量上传' ],
+];
+
+/** Traditional Chinese
+ */
+$specialPageAliases['zh-hant'] = [
+	'BatchUpload' => [ '批次上傳' ],
+];
+
+/** Traditional Chinese, Hong Kong
+ */
+$specialPageAliases['zh-hk'] = [
+	'BatchUpload' => [ '批次上載' ],
+];

--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -127,10 +127,11 @@ class UploadButtonRenderer {
 
 		if ( $templateName !== '' ) {
 			array_shift( $args );
-			foreach ( $args as $node ) {
-				$paramProvider->addTemplateParameter( $node );
-			}
 		}
+		foreach ( $args as $node ) {
+			$paramProvider->addTemplateParameter( $node );
+		}
+
 		return $paramProvider;
 	}
 


### PR DESCRIPTION
Currently, the default upload text for new files is very simple, they simply just add a template using subpage name, and using additional parameters when call through parser function.

On some wikis, uploaded files need to be tagged with copyright information. which is mandatory or recommended. Currently, SimpleBatchUpload do not have the ability to set a default upload text on root page, it means editors needs to write the upload text manually, and there is usually someone forget it, increases workload for maintenance on forementioned wikis.

This PR allows administrators set default texts for root page and subpages, at `MediaWiki:Simplebatchupload-filesummary` and `MediaWiki:Simplebatchupload-filesummary-<subpagename>` respectively, the message for the root page is also registered in the message file. Additionally, optional template parameters passed through parser functions can be substituted on `$1` in these system messages (prefix `|` included).

Some other changes are also made in this PR:
- Registered `simplebatchupload-parameters` system message in the message file, a message for an existing feature.
- Added support for unordered list in `simplebatchupload-parameters` system message, prettier in format, like the format in `MediaWiki:Gadgets-definition`.
- Added support for unnamed parser function call (e.g. `{{#batchupload:|arg1|arg2}}`).
- Added special page aliases for Chinese variants (`zh-hans`, `zh-hant`, `zh-hk`).

This PR should be compatible with existing usages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SimpleBatchUpload now supports Simplified Chinese (zh-hans), Traditional Chinese (zh-hant), and Traditional Chinese (Hong Kong)
  * Added localization strings enabling customizable default file summaries and configuration parameters for enhanced flexibility

* **Improvements**
  * Enhanced parameter parsing logic for more robust and flexible customization options while maintaining backward compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->