### PR TITLE
Add MediaWiki 1.44 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_35'
-            php: '8.0'
-            experimental: false
-          - mw: 'REL1_39'
+          - mw: 'REL1_43'
             php: '8.1'
             experimental: false
-          - mw: 'REL1_40'
-            php: '8.2'
-            experimental: false
-          - mw: 'REL1_41'
-            php: '8.2'
-            experimental: false
-          - mw: 'REL1_42'
+          - mw: 'REL1_43'
             php: '8.2'
             experimental: false
           - mw: 'REL1_43'

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,11 @@
 	"license": "GPL-2.0-or-later",
 	"authors": [
 		{
+			"name": "Professional Wiki",
+			"email": "info@Professional.Wiki",
+			"homepage": "https://Professional.Wiki"
+		},
+		{
 			"name": "Stephan Gambke",
 			"email": "s7eph4n@gmail.com",
 			"role": "Developer"

--- a/extension.json
+++ b/extension.json
@@ -1,9 +1,9 @@
 {
 	"name": "SimpleBatchUpload",
-	"version": "2.0.1",
+	"version": "3.0.0",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
-		"[https://professional.wiki/ Professional.Wiki]",
+		"[https://professional.wiki/ Professional Wiki]",
 		"..."
 	],
 	"url": "https://www.mediawiki.org/wiki/Extension:SimpleBatchUpload",
@@ -12,7 +12,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">=1.35"
+		"MediaWiki": ">=1.43"
 	},
 	"MessagesDirs": {
 		"SimpleBatchUpload": [

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,10 @@
 ## Release Notes
 
+### SimpleBatchUpload 3.0.0
+
+* Raised minimum MediaWiki version to 1.43
+* Added support for MediaWiki 1.44
+
 ### SimpleBatchUpload 2.0.1
 
 Released on December 7, 2023.

--- a/src/ParameterProvider.php
+++ b/src/ParameterProvider.php
@@ -24,7 +24,7 @@
 
 namespace MediaWiki\Extension\SimpleBatchUpload;
 
-use Message;
+use MediaWiki\Message\Message;
 
 /**
  * Class ParameterProvider

--- a/src/SimpleBatchUpload.php
+++ b/src/SimpleBatchUpload.php
@@ -23,7 +23,7 @@
 namespace MediaWiki\Extension\SimpleBatchUpload;
 
 use MediaWiki\MediaWikiServices;
-use Parser;
+use MediaWiki\Parser\Parser;
 
 /**
  * Class ExtensionManager

--- a/src/SpecialBatchUpload.php
+++ b/src/SpecialBatchUpload.php
@@ -24,7 +24,7 @@
 
 namespace MediaWiki\Extension\SimpleBatchUpload;
 
-use SpecialPage;
+use MediaWiki\SpecialPage\SpecialPage;
 
 /**
  * Class SpecialBatchUpload

--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -23,9 +23,9 @@
  */
 
 namespace MediaWiki\Extension\SimpleBatchUpload;
-use Parser;
-use PPFrame;
-use Html;
+use MediaWiki\Html\Html;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\PPFrame;
 
 /**
  * Class UploadButtonRenderer

--- a/tests/phpunit/SimpleBatchUploadTest.php
+++ b/tests/phpunit/SimpleBatchUploadTest.php
@@ -22,8 +22,8 @@
 
 namespace MediaWiki\Extension\SimpleBatchUpload\Tests;
 
-use OutputPage;
-use Parser;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Parser\Parser;
 use MediaWiki\Extension\SimpleBatchUpload\SimpleBatchUpload;
 
 /**


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/SimpleBatchUpload/issues/68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for MediaWiki 1.44.
  * Updated extension metadata and release notes for version 3.0.0.
  * Added "Professional Wiki" as an author in the project metadata.

* **Breaking Changes**
  * Increased the minimum required MediaWiki version to 1.43.

* **Chores**
  * Updated test matrix to focus on newer MediaWiki and PHP versions.
  * Improved namespace clarity in import statements throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->