### PR TITLE
Do not add general modules to the styles queue

### DIFF
--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -111,8 +111,9 @@ class UploadButtonRenderer {
 	 * @param \ParserOutput | \OutputPage $output
 	 */
 	protected function addModulesToOutput( $output ) {
+		// addModules() also loads the modules' CSS (jquery-file-upload comes in as a
+		// dependency); they are general modules and must not go through addModuleStyles().
 		$output->addModules( [ 'ext.SimpleBatchUpload' ] );
-		$output->addModuleStyles( [ 'ext.SimpleBatchUpload', 'ext.SimpleBatchUpload.jquery-file-upload' ] );
 	}
 
 	/**


### PR DESCRIPTION
## Problem

On every page that renders an upload button (the `{{#batchupload:}}` parser function, or `Special:BatchUpload`), MediaWiki logs two errors on the `resourceloader` channel:

```
Unexpected general module "ext.SimpleBatchUpload" in styles queue.
Unexpected general module "ext.SimpleBatchUpload.jquery-file-upload" in styles queue.
```

## Cause

`UploadButtonRenderer::addModulesToOutput()` passed both modules to `addModuleStyles()`. Both declare `scripts` as well as `styles` in `extension.json`, so they are general (`LOAD_GENERAL`) modules. `addModuleStyles()` is only for style-only modules: core (`ClientHtml`) rejects general modules there, logs the error at `error` level, and skips them. So the call never contributed any styles, it only produced the log entries, repeated on every view of any page carrying the button.

## Fix

`addModules( 'ext.SimpleBatchUpload' )` already loads both modules' scripts **and** styles (`ext.SimpleBatchUpload.jquery-file-upload` is a declared dependency of `ext.SimpleBatchUpload`), so removing the redundant `addModuleStyles()` call leaves asset loading unchanged and removes the errors.

## Behaviour

No functional change: the button and its CSS still load via the general-module path. The only difference is that the two error log lines are gone.

## Tests

No test added. The contract worth pinning ("no general module lands in the styles queue") is a ResourceLoader-level outcome; a unit test on this method could only assert the internal `addModules`/`addModuleStyles` call shape, which binds to implementation rather than behaviour. The method now carries a short comment documenting why only `addModules()` is used. A behaviour-level regression test would require integration-level page rendering; noting that as a coverage gap rather than adding a mock-based pin.