### PR TITLE
Remove comment from addModulesToOutput

### DIFF
--- a/src/UploadButtonRenderer.php
+++ b/src/UploadButtonRenderer.php
@@ -111,8 +111,6 @@ class UploadButtonRenderer {
 	 * @param \ParserOutput | \OutputPage $output
 	 */
 	protected function addModulesToOutput( $output ) {
-		// addModules() also loads the modules' CSS (jquery-file-upload comes in as a
-		// dependency); they are general modules and must not go through addModuleStyles().
 		$output->addModules( [ 'ext.SimpleBatchUpload' ] );
 	}
 


### PR DESCRIPTION
Removes the inline comment on `addModulesToOutput()`. The rationale for loading the modules through `addModules()` only is recorded in the commit history.