### PR TITLE
Support the MediaWiki 1.46 PHPUnit test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           - mw: 'REL1_45'
             php: '8.4'
             experimental: false
+          - mw: 'REL1_46'
+            php: '8.4'
+            experimental: true
           - mw: 'master'
             php: '8.5'
             experimental: true
@@ -80,10 +83,30 @@ jobs:
         run: php maintenance/update.php --quick
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php -c extensions/SimpleBatchUpload/
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php -c extensions/SimpleBatchUpload/
+          else
+            # MW 1.46 and later
+            if [ ! -f phpunit.xml.template ]; then
+              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+            fi
+            composer phpunit:config
+            MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/SimpleBatchUpload/tests/phpunit
+          fi
 
       - name: Run PHPUnit with code coverage
-        run: php tests/phpunit/phpunit.php -c extensions/SimpleBatchUpload/ --coverage-clover coverage.xml
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php -c extensions/SimpleBatchUpload/ --coverage-clover coverage.xml
+          else
+            # MW 1.46 and later
+            if [ ! -f phpunit.xml.template ]; then
+              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
+            fi
+            composer phpunit:config
+            MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/SimpleBatchUpload/tests/phpunit --coverage-clover coverage.xml
+          fi
 
       - name: Upload code coverage
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,20 +94,3 @@ jobs:
             composer phpunit:config
             MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/SimpleBatchUpload/tests/phpunit
           fi
-
-      - name: Run PHPUnit with code coverage
-        run: |
-          if [ -f tests/phpunit/phpunit.php ]; then
-            php tests/phpunit/phpunit.php -c extensions/SimpleBatchUpload/ --coverage-clover coverage.xml
-          else
-            # MW 1.46 and later
-            if [ ! -f phpunit.xml.template ]; then
-              wget -q -O phpunit.xml.template "https://raw.githubusercontent.com/wikimedia/mediawiki/${{ matrix.mw }}/phpunit.xml.template"
-            fi
-            composer phpunit:config
-            MEDIAWIKI_HAS_INTEGRATION_TESTS=1 vendor/bin/phpunit -c phpunit.xml extensions/SimpleBatchUpload/tests/phpunit --coverage-clover coverage.xml
-          fi
-
-      - name: Upload code coverage
-        run: bash <(curl -s https://codecov.io/bash)
-        if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Problem

MediaWiki 1.46 removes `tests/phpunit/phpunit.php`. The CI PHPUnit steps call it directly, so the `master` matrix row (1.46-dev) fails at the "Run PHPUnit" step:

```
Could not open input file: tests/phpunit/phpunit.php
```

## Changes

- Gate the PHPUnit step on the presence of the old entrypoint: where `tests/phpunit/phpunit.php` exists (MW <= 1.45), keep the current invocation; on newer MediaWiki, fetch the core `phpunit.xml.template`, generate the runner config with `composer phpunit:config`, and run `vendor/bin/phpunit` against the extension's test directory. This mirrors the approach already used for Chameleon and BootstrapComponents.
- Add a `REL1_46` matrix row (experimental) so the new path is exercised on a stable branch, not only on `master`.
- Remove the code coverage step and its upload. The coverage step re-ran the whole suite on every job, and the upload used the codecov bash uploader (sunset in 2022), so it produced and uploaded nothing. The suite now runs once per job.

## Note on coverage

Rather than repair the dead uploader, coverage is dropped for now. This keeps SimpleBatchUpload consistent with the rest of the stack, where coverage is not collected (Chameleon and FontAwesome have none; BootstrapComponents' coverage path exists but is disabled).

Switching to the maintained `codecov/codecov-action` was considered but deferred: it requires the repository to be onboarded to Codecov with a `CODECOV_TOKEN` secret, and it would make this the only extension in the stack reporting coverage. Whether to (re)introduce coverage is better decided stack-wide than bolted on here.