### PR TITLE
Release version 3.0.1

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleBatchUpload",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://professional.wiki/ Professional Wiki]",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### SimpleBatchUpload 3.0.1
+
+Released on July 1, 2026.
+
+* Fixed ResourceLoader errors logged on pages that display the upload button
+
 ### SimpleBatchUpload 3.0.0
 
 Released on August 15, 2025.


### PR DESCRIPTION
Patch release.

## User-facing

- Fixes the ResourceLoader errors ("Unexpected general module ... in styles queue") that MediaWiki logged on every page rendering the upload button.

Bumps `extension.json` to 3.0.1 and adds the release-notes entry, matching the previous patch-release convention. Internal CI changes since 3.0.0 (MW 1.46 test runner support) are also included but do not affect the extension at runtime.

The release date in `release-notes.md` is set to July 1, 2026; adjust if the tag is cut on a different day.