### PR TITLE
Release version 3.0.2

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleBatchUpload",
-	"version": "3.0.1",
+	"version": "3.0.2",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://professional.wiki/ Professional Wiki]",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### SimpleBatchUpload 3.0.2
+
+Released on July 1, 2026.
+
+* Re-release of 3.0.1 to correct a bad release tag; no code changes
+
 ### SimpleBatchUpload 3.0.1
 
 Released on July 1, 2026.


### PR DESCRIPTION
Patch release carrying the ResourceLoader styles-queue fix.

`3.0.2` supersedes `3.0.1`: the `3.0.1` tag was published before this release metadata was merged, and Packagist enforces stable-version immutability, so re-tagging `3.0.1` is rejected. Per Packagist's guidance, the correct fix for a published version is to release a new one rather than overwrite the tag.

- `extension.json` → 3.0.2
- `release-notes.md`: the `3.0.1` entry is kept, with a short `3.0.2` note recording that it re-releases 3.0.1 to correct a bad release tag, so the number isn't silently dropped.

No code changes over `3.0.1`.