### PR TITLE
Stop using deprecated SpecialPage constructor parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
             experimental: false
           - mw: 'REL1_46'
             php: '8.4'
-            experimental: true
+            experimental: false
           - mw: 'master'
             php: '8.5'
             experimental: true

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SimpleBatchUpload",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
 		"[https://professional.wiki/ Professional Wiki]",

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,11 @@
 ## Release Notes
 
+### SimpleBatchUpload 3.0.3
+
+Released on August 5, 2026.
+
+* Fixed deprecation warning shown on MediaWiki 1.46
+
 ### SimpleBatchUpload 3.0.2
 
 Released on July 1, 2026.

--- a/src/SpecialBatchUpload.php
+++ b/src/SpecialBatchUpload.php
@@ -33,13 +33,12 @@ use MediaWiki\SpecialPage\SpecialPage;
  */
 class SpecialBatchUpload extends SpecialPage {
 
-	/**
-	 * @param string $name Name of the special page, as seen in links and URLs
-	 * @param string $restriction User right required, e.g. "block" or "delete"
-	 * @param bool $listed Whether the page is listed in Special:Specialpages
-	 */
-	public function __construct( $name = '', $restriction = '', $listed = true ) {
-		parent::__construct( 'BatchUpload', 'upload', $listed );
+	public function __construct() {
+		parent::__construct( 'BatchUpload' );
+	}
+
+	public function getRestriction(): string {
+		return 'upload';
 	}
 
 	/**

--- a/tests/phpunit/SpecialBatchUploadTest.php
+++ b/tests/phpunit/SpecialBatchUploadTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace MediaWiki\Extension\SimpleBatchUpload\Tests;
+
+use MediaWiki\Extension\SimpleBatchUpload\SpecialBatchUpload;
+
+/**
+ * @covers \MediaWiki\Extension\SimpleBatchUpload\SpecialBatchUpload
+ * @group SimpleBatchUpload
+ */
+class SpecialBatchUploadTest extends \PHPUnit\Framework\TestCase {
+
+	public function testRequiresUploadRight() {
+		$this->assertSame( 'upload', ( new SpecialBatchUpload() )->getRestriction() );
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/SimpleBatchUpload/issues/81

MediaWiki 1.46 deprecated the `$restriction`, `$listed`, `$function`, `$file` and `$includable` parameters of the
`SpecialPage` constructor. `SpecialBatchUpload` passed three of them, so MediaWiki emitted a deprecation warning
every time the special page was constructed.

Only the page name is passed to the parent constructor now, and the required `upload` right is declared by
overriding `getRestriction()`. Our own constructor already ignored its `$name` and `$restriction` arguments, and
`$listed` was only ever the default, so no caller loses anything.

`getRestriction()` is untyped in MediaWiki 1.43 to 1.45 and declared as `: string` in 1.46, so the override carries
the return type to stay compatible across the whole supported range.

Also bumps the version to 3.0.3 and records the fix in the release notes. The MediaWiki 1.46 CI job is no
longer marked experimental now that 1.46 is released, so failures against it block. Only the job tracking
MediaWiki master stays non-blocking.

Verified against a local MediaWiki 1.46 install: the new test reproduces the reported warning before the fix and
passes after it, `Special:BatchUpload` renders without the warning (checked with Playwright), and the page still
refuses access to users without the `upload` right.

> <sub>AI-authored — Claude Code, `Opus 5 (1M context)`; one-line ask from @malberts (the issue URL), plus a follow-up asking for the version bump; diff not yet human-reviewed; regression test seen failing then passing on a local MediaWiki 1.46 + PHP 8.3 install, before/after also checked in the browser.</sub>



