### PR TITLE
Remove PHP version requirement from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
 		"issues": "https://github.com/ProfessionalWiki/SimpleBatchUpload/issues"
 	},
 	"require": {
-		"php": ">=8.0",
 		"composer/installers": "^2|^1.0.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
Already covered by MediaWiki 1.43.